### PR TITLE
Verification: Better parsing for verify basic

### DIFF
--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -1,6 +1,8 @@
 import json
 import re
 from asyncio import TimeoutError
+from dataclasses import dataclass
+from typing import Optional
 
 import config
 import discord
@@ -11,6 +13,38 @@ from email.message import EmailMessage
 from utils import checks
 from utils.l10n import get_l10n
 from utils.utils import assign_student_roles, generateID
+
+
+@dataclass
+class BasicInfo:
+    branch: Optional[str]
+    section: Optional[str]
+    roll: Optional[int]
+
+
+def parse_verify_basic(params: str) -> BasicInfo:
+    roll = None
+    branch = None
+    section = None
+
+    if roll_no := re.search(r'\d{4,}', params):
+        roll = int(roll_no.group(0))
+
+    # try XY-A or XY-A2
+    if section_name := re.search(r'([A-Z]{2})[- ]?([ABC])', params, re.I):
+        branch = section_name.group(1)
+        section = section_name.group(2)
+
+    # try XY-01 or XY-1
+    elif sect := re.search(r'([A-Z]{2})[- ]?(\d{1,2})', params, re.I):
+        branch = sect.group(1)
+        sec_num = int(sect.group(2))
+        if sec_num > 9 or sec_num < 1:
+            section = None
+        else:
+            section = ["A", "B", "C"][(sec_num - 1) // 3]
+
+    return BasicInfo(branch, section, roll)
 
 
 class Verify(commands.Cog):
@@ -122,7 +156,7 @@ class Verify(commands.Cog):
         await author.edit(nick=first_name)
 
     @verify.command()
-    async def basic(self, ctx, section: str, roll_no: int):
+    async def basic(self, ctx, *, params: str):
         """Link a Discord account to a record in the database.
 
         Parameters
@@ -143,6 +177,23 @@ class Verify(commands.Cog):
         if str(ctx.author.id) in self.codes:
             await ctx.reply('pending-verification')
             return
+
+        info = parse_verify_basic(params)
+
+        if info.roll is None:
+            await ctx.reply(self.l10n.format_value('rollno-not-provided'))
+            return
+
+        if info.branch is None:
+            await ctx.reply(self.l10n.format_value('branch-not-provided'))
+            return
+
+        if info.section is None:
+            await ctx.reply(self.l10n.format_value('section-not-provided'))
+            return
+
+        roll_no = info.roll
+        section = f'{info.branch}-{info.section}'.upper()
 
         tuple = self.bot.c.execute(
             '''select Section, Subsection, Name,

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -31,18 +31,9 @@ def parse_verify_basic(params: str) -> BasicInfo:
         roll = int(roll_no.group(0))
 
     # try XY-A or XY-A2
-    if section_name := re.search(r'([A-Z]{2})[- ]?([ABC])', params, re.I):
+    if section_name := re.search(r'([A-Z]{2})[- ]?([ABC])?', params, re.I):
         branch = section_name.group(1)
         section = section_name.group(2)
-
-    # try XY-01 or XY-1
-    elif sect := re.search(r'([A-Z]{2})[- ]?(\d{1,2})', params, re.I):
-        branch = sect.group(1)
-        sec_num = int(sect.group(2))
-        if sec_num > 9 or sec_num < 1:
-            section = None
-        else:
-            section = ["A", "B", "C"][(sec_num - 1) // 3]
 
     return BasicInfo(branch, section, roll)
 

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -203,7 +203,7 @@ class Verify(commands.Cog):
         ).fetchone()
 
         if not tuple:
-            await ctx.reply(self.l10n.format_value('record-notfound'))
+            await ctx.reply(self.l10n.format_value('roll-not-in-database'))
             return
 
         guild = ctx.guild

--- a/l10n/en-gb/verification.ftl
+++ b/l10n/en-gb/verification.ftl
@@ -25,3 +25,7 @@ email-mismatch = The email that you entered does not match your institute email.
 
 section-notfound = '{$section}' is not an existing section. Please re-check the entered details and try again
 email-not-received = You did not receive any email yet.
+
+section-not-given = Section is required.
+rollno-not-given = Roll number is required.
+branch-not-given = Branch is required.

--- a/l10n/en-gb/verification.ftl
+++ b/l10n/en-gb/verification.ftl
@@ -17,7 +17,7 @@ pending-verification = Please complete your pending verification before trying a
 record-claimed = The details you entered is of a record already claimed by {$user}.
             An email has been sent to your institute email ID, `{$email}`. Paste the code here to complete your verification.
 
-record-notfound = The requested record was not found. Please re-check the entered details and try again
+roll-not-in-database = Please re-check the entered roll number.
 
 section-mismatch = The section that you entered does not match that of the roll number that you entered. Please re-check the entered details and try again
 email-mismatch = The email that you entered does not match your institute email. Please try again with a valid email.


### PR DESCRIPTION
some of the supported formats:
`%verify basic 12241234 CSA`
`%verify basic 12241234 CSB6`
`%verify basic 12241234 CS B6`
`%verify basic 12241234 EC 01`
`%verify basic 12241234 EC-05`
`%verify basic EC 01 12234123`
`%verify basic ec a 12234123`